### PR TITLE
Fixed issue where empty song links lead to crashes

### DIFF
--- a/thecypher/__init__.py
+++ b/thecypher/__init__.py
@@ -57,7 +57,9 @@ def get_lyrics(artist):
                 albums[title]['year'] = album_year
         if node.name == 'ol':
             for song in node:
-                track_node = song.find_all('a')[0]
+                track_a = song.find_all('a')
+                if not track_a: continue
+                track_node = track_a[0]
                 track_name = track_node.text
                 track_href = track_node.get('href')
                 if 'tracks' not in albums[title]:


### PR DESCRIPTION
If a track has no links, cypher currently crashes.
Example: L.O.C. with "Intro" from the album "Nyt Fra Vestfronten 2 (2008)" http://lyrics.wikia.com/wiki/L.O.C.#Nyt_Fra_Vestfronten_2_.282008.29

Cypher should probably just skip that track and move on. 